### PR TITLE
Scale physics based on `frameRate()`

### DIFF
--- a/src/classes/ball.js
+++ b/src/classes/ball.js
@@ -2,6 +2,12 @@
 import constrainAngle from '../helpers/constrainAngle.js';
 import ClickableObject from './clickableObject.js';
 
+const GRAVITY_60_FPS = 0.35;
+const SPEEDLIMIT_60_FPS = 17;
+
+const GRAVITY_30_FPS = 1.3;
+const SPEEDLIMIT_30_FPS = 30;
+
 class Ball extends ClickableObject {
   constructor(x, y, radius, animation, animationSpeed, hitSound) {
     // Inherits properties all clickable objects need
@@ -34,13 +40,20 @@ class Ball extends ClickableObject {
 
     // Magic number constant land:
     this.restitution = 0.8;
-    this.gravity = createVector(0, 0.35);
-    this.speedLimit = 17;
+    this.gravity = createVector(0, GRAVITY_60_FPS);
+    this.speedLimit = SPEEDLIMIT_60_FPS;
 
     // How hard does the user hit the ball?
     this.hitMagnitude = this.gravity.y * 100;
     // For applying hitMagnitude force to ball
     this.hitForce = createVector();
+  }
+
+  scalePhysics() {
+    const fps = frameRate();
+    this.gravity.y = map(fps, 30, 60, GRAVITY_30_FPS, GRAVITY_60_FPS, true);
+    this.speedLimit = map(fps, 30, 60, SPEEDLIMIT_30_FPS, SPEEDLIMIT_60_FPS, true);
+    this.hitMagnitude = this.gravity.y * 100;
   }
 
   applyForce(force) {
@@ -118,6 +131,7 @@ class Ball extends ClickableObject {
 
   update() {
     if (this.frozen) return;
+    this.scalePhysics();
 
     // Bounce off side walls
     this.wallBounce();

--- a/src/classes/multiball.js
+++ b/src/classes/multiball.js
@@ -1,6 +1,9 @@
 /* eslint-disable import/extensions */
 import ClickableObject from './clickableObject.js';
 
+const GRAVITY_60_FPS = 3;
+const GRAVITY_30_FPS = 6;
+
 class MultiBallPowerup extends ClickableObject {
   // TODO: Add animation and sound effect for getting powerup
   constructor(x, y, radius, animation, animationSpeed, hitSound) {
@@ -35,7 +38,7 @@ class MultiBallPowerup extends ClickableObject {
   }
 
   update() {
-    this.pos.y += 3;
+    this.pos.y += map(frameRate(), 30, 60, GRAVITY_30_FPS, GRAVITY_60_FPS, true);
   }
 
   animate() {


### PR DESCRIPTION
Fixes #28 

Created constants for handling ideal physics at 60fps and 30fps (iOS lower power is throttled to 30).  Physics are then scaled using `map()` (for example: `map(fps, 30, 60, GRAVITY_30_FPS, GRAVITY_60_FPS, true)`).

The general idea seems to work well enough, but I could definitely use your game testing on whether or not it feels good when we manually throttle `frameRate()`.  Not sure how to test mobile besides in production ¯\\_(ツ)_/¯.

When/if testing, you would mostly fiddle with the 30 FPS constants and see how it changes things.

```js
const GRAVITY_60_FPS = 0.35;
const SPEEDLIMIT_60_FPS = 17;

const GRAVITY_30_FPS = 1.3;
const SPEEDLIMIT_30_FPS = 30;
```

The same idea has been applied to multiBallPowerUp, but that one seems to be working well enough and is definitely lower priority/risk.