### PR TITLE
Remove point for clicking powerup

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -74,6 +74,7 @@ const spawnPowerup = () => {
       const y = height;
       const ball = new Ball(x, y, 50, animationBall, 0.15, hitSound);
       ball.clickEvent(x, y);
+      ball.hitCount = 0;
       balls.push(ball);
       multiBallPowerup = null;
     }


### PR DESCRIPTION
Closes #29 

Not sure if we decided to keep the point for powerup based on gameplay reasons or a lack of wanting to fix it.

Up to you if we:
* Keep the point for clicking the power-up -> close this PR w/o merging and close issue #29
* Remove the point for clicking the power-up -> merge this PR (merging should auto close issue #29)