### PR TITLE
save high score as a cookie

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -92,6 +92,9 @@ const resetGame = () => {
 
   if (totalScore > sessionBestScore) {
     sessionBestScore = totalScore;
+    // writeHighScoreCookie() will check if provided score
+    // is greater than currently saved highscore
+    // score only written if greater than current high
     writeHighScoreCookie(sessionBestScore);
   }
 
@@ -137,6 +140,8 @@ function draw() {
     text('Bounce\nthe Ball', width / 2, height / 4);
     pop();
 
+    // If never played then readHighScoreCookie() returns -1
+    // displayBestScore() only displays if score > 0
     displayBestScore(readHighScoreCookie(), gameFont);
   }
 

--- a/sketch.js
+++ b/sketch.js
@@ -2,6 +2,7 @@
 /* eslint-disable import/extensions */
 import Ball from './src/classes/ball.js';
 import { displayBestScore, displayScore } from './src/helpers/displayScores.js';
+import { readHighScoreCookie, writeHighScoreCookie } from './src/helpers/saveHighScoreCookie.js';
 import MultiBallPowerup from './src/classes/multiball.js';
 import readSpriteSheet from './src/helpers/readSpritesheet.js';
 
@@ -91,6 +92,7 @@ const resetGame = () => {
 
   if (totalScore > sessionBestScore) {
     sessionBestScore = totalScore;
+    writeHighScoreCookie(sessionBestScore);
   }
 
   totalScore = 0;
@@ -135,7 +137,7 @@ function draw() {
     text('Bounce\nthe Ball', width / 2, height / 4);
     pop();
 
-    displayBestScore(sessionBestScore, gameFont);
+    displayBestScore(readHighScoreCookie(), gameFont);
   }
 
   balls.forEach((ball) => {

--- a/src/helpers/displayScores.js
+++ b/src/helpers/displayScores.js
@@ -1,5 +1,5 @@
 export const displayBestScore = (score, gameFont, x = 10, txtSize = 30) => {
-  if (score === 0) return;
+  if (score <= 0) return;
 
   push();
 

--- a/src/helpers/saveHighScoreCookie.js
+++ b/src/helpers/saveHighScoreCookie.js
@@ -1,0 +1,65 @@
+/**
+ * Write a cookie with an expiration date
+ * Source: https://stackoverflow.com/a/2138471/5731525
+ *
+ * @param {*} key name of cookie
+ * @param {*} value value of cookie
+ * @param {*} days how many days until cookie expires
+ */
+function setCookie(key, value, days) {
+  let expires = '';
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    expires = `; expires=${date.toUTCString()}`;
+  }
+  document.cookie = `${key}=${value || ''}${expires}; path=/`;
+}
+
+/**
+ * Read the value of a cookie with a given name
+ * Returns null if no cookie matching name is found
+ *
+ * Source: https://stackoverflow.com/a/2138471/5731525
+ * @param {*} name name of cookie
+ */
+function getCookie(name) {
+  const nameEQ = `${name}=`;
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i += 1) {
+    let c = ca[i];
+    while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+}
+
+/**
+ * Delete a cookie by name
+ *
+ * Source: https://stackoverflow.com/a/2138471/5731525
+ * @param {*} name name of cookie
+ */
+function eraseCookie(name) {
+  document.cookie = `${name}=; Max-Age=-99999999;`;
+}
+
+export function readHighScoreCookie() {
+  const highScoreStr = getCookie('high_score');
+  const highScore = parseInt(highScoreStr, 10);
+  if (highScore) {
+    return highScore;
+  }
+  return -1;
+}
+
+export function writeHighScoreCookie(score) {
+  const cookieName = 'high_score';
+  const daysTillExpires = 7;
+
+  const currentHighScore = readHighScoreCookie();
+
+  if (score > currentHighScore) {
+    setCookie(cookieName, score, daysTillExpires);
+  }
+}


### PR DESCRIPTION
Most of the code is ripped from [a StackOverflow post](https://stackoverflow.com/a/2138471/5731525).

## Changes:

Code to save a user's high score as a cookie (set to expire in a week), and additional code to read high score.

## To test:

* Pull down changes. 
* Serve locally. 
* Play a round. 
* Refresh Page. 
* There should be a high score in the top left corner from the previous session's cookied high score.  
* Open a new tab in incognito mode.  
* There should now be no high score in the top left corner.